### PR TITLE
🐛 Fix validator Error

### DIFF
--- a/sitemapr/models.py
+++ b/sitemapr/models.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from decimal import Decimal
 from typing import Literal, TypeVar
 
-from pydantic import BaseModel, ValidationError, validator
+from pydantic import BaseModel, field_validator
 
 T = TypeVar("T")
 
@@ -32,18 +32,17 @@ class SiteMapUrl(BaseModel):
     changefreq: ChangeFreq | None = None  # Google ignores this
     priority: str | None = None  # Google ignores this
 
-    @validator("priority")
+    @field_validator("priority")
+    @classmethod
     def validate_priority(cls, v: str | None) -> str | None:
         if v is None:
             return v
         try:
             priority = Decimal(v)
         except Exception as e:
-            raise ValidationError(
-                "Priority must be a valid decimal string between 0.0 and 1.0"
-            ) from e
+            raise ValueError("Priority must be a valid decimal string between 0.0 and 1.0") from e
 
         if 0 <= priority <= 1:
             return f"{priority:.1f}"
 
-        raise ValidationError("Priority must be between 0.0 and 1.0")
+        raise ValueError("Priority must be between 0.0 and 1.0")


### PR DESCRIPTION
### TL;DR

Modified the validators in the `sitemapr/models.py` file by replacing the `@validator` decorator with `@field_validator`, and changed exception types in `validate_priority` method.

### What changed?

- Replaced the `@validator` with `@field_validator` in `sitemapr/models.py`.
- Updated the `validate_priority` method to raise `ValueError` instead of `ValidationError` for invalid priority values.
- Made `validate_priority` a class method by adding `@classmethod`.

### How to test?

1. Run the unit tests associated with `sitemapr` models.
2. Verify that the validation logic for the `priority` field in the `SiteMapUrl` class handles both valid and invalid inputs correctly.

### Why make this change?

The change was made to utilize the new `@field_validator` decorator provided by Pydantic, which is more appropriate for field-level validation as opposed to the older `@validator` decorator. Additionally, the change in exception type aims to standardize how errors are raised and handled within the project.

---

